### PR TITLE
png포맷 jpeg로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 	implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.4'
 
 	implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.4'
+
+	implementation 'commons-io:commons-io:2.8.0'
+	implementation 'commons-fileupload:commons-fileupload:1.4'
 	
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/individual/freshplace/controller/ImageController.java
+++ b/src/main/java/individual/freshplace/controller/ImageController.java
@@ -11,12 +11,11 @@ import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/admin")
 public class ImageController {
 
     private final ImageUploadService imageUploadService;
 
-    @PostMapping("/image/upload")
+    @PostMapping("/admin/image/upload")
     @ResponseStatus(HttpStatus.ACCEPTED)
     public ImageUploadResponse itemsUploadRequest(@RequestParam("objectName") Long objectName,
                                                                   @RequestParam("image") MultipartFile multipartFile) {

--- a/src/main/java/individual/freshplace/service/ImageUploadService.java
+++ b/src/main/java/individual/freshplace/service/ImageUploadService.java
@@ -39,7 +39,8 @@ public class ImageUploadService {
 
     private void resizingUpload(final Long itemId, final MultipartFile multipartFile) {
         CompletableFuture
-                .supplyAsync(() -> ImageUtils.imageResize(multipartFile, ImageFormat.STANDARD.getWeight(), ImageFormat.STANDARD.getHeight()))
+                .supplyAsync(() -> multipartFile.getContentType().equals(Folder.IMAGE.getDirectoryName() + SLASH + ImageFormat.LETTERS.getExtension()) ? ImageUtils.pngToJpeg(multipartFile) : multipartFile)
+                .thenApply((file) -> ImageUtils.imageResize(file, ImageFormat.STANDARD.getWeight(), ImageFormat.STANDARD.getHeight()))
                 .thenApply((resizingImage) -> s3Uploader.upload(getDirectoryName(), itemId, Folder.RESIZE.getDirectoryName(), resizingImage))
                 .thenAccept((resizingItemImageUrl) -> createItemEntityAndInsert(resizingItemImageUrl));
     }

--- a/src/main/java/individual/freshplace/util/ImageUtils.java
+++ b/src/main/java/individual/freshplace/util/ImageUtils.java
@@ -1,16 +1,22 @@
 package individual.freshplace.util;
 
 import individual.freshplace.util.constant.ErrorCode;
+import individual.freshplace.util.constant.ImageFormat;
+import individual.freshplace.util.exception.FileConvertFiledException;
 import individual.freshplace.util.exception.FileUploadFailedException;
+import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.fileupload.disk.DiskFileItem;
+import org.apache.commons.io.IOUtils;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.multipart.commons.CommonsMultipartFile;
 
 import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.awt.image.PixelGrabber;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
+import java.nio.file.Files;
+import java.util.Arrays;
 
 public class ImageUtils {
 
@@ -41,8 +47,34 @@ public class ImageUtils {
         }
     }
 
+    public static MultipartFile pngToJpeg(MultipartFile multipartFile) {
+
+        try (InputStream inputStream = multipartFile.getInputStream()){
+            File next = new File(findTitleByFileName(multipartFile.getOriginalFilename()) + "." + ImageFormat.STANDARD.getExtension());
+            BufferedImage initBufferedImage = ImageIO.read(inputStream);
+            BufferedImage convertBufferedImage  = new BufferedImage(initBufferedImage.getWidth(), initBufferedImage.getHeight(), BufferedImage.TYPE_INT_RGB);
+            convertBufferedImage.createGraphics().drawImage(initBufferedImage, 0, 0, Color.white, null);
+            ImageIO.write(convertBufferedImage, ImageFormat.STANDARD.getExtension(), next);
+            FileItem fileItem = new DiskFileItem(next.getName(), Files.probeContentType(next.toPath()), false, next.getName(), (int) next.length(), next.getParentFile());
+            InputStream fileInputStream = new FileInputStream(next);
+            OutputStream outputStream = fileItem.getOutputStream();
+            IOUtils.copy(fileInputStream, outputStream);
+            return new CommonsMultipartFile(fileItem);
+
+        } catch (IOException e) {
+            throw new FileConvertFiledException(ErrorCode.FAILED_FILE_TO_STREAM, multipartFile.getOriginalFilename());
+        }
+
+
+    }
+
     private static String findExtensionByFileName(String fileName) {
         String[] split = fileName.split("\\.");
         return split[split.length-1];
+    }
+
+    private static String findTitleByFileName(String fileName) {
+        String[] split = fileName.split("\\.");
+        return Arrays.stream(split).limit(split.length-1).reduce(String::concat).get();
     }
 }

--- a/src/main/java/individual/freshplace/util/constant/ImageFormat.java
+++ b/src/main/java/individual/freshplace/util/constant/ImageFormat.java
@@ -7,8 +7,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ImageFormat {
 
-    STANDARD(550, 700);
+    STANDARD(550, 700, "jpg"),
+    LETTERS(550, 700, "png");
 
     private int weight;
     private int height;
+    private String extension;
 }

--- a/src/main/java/individual/freshplace/util/exception/FileConvertFiledException.java
+++ b/src/main/java/individual/freshplace/util/exception/FileConvertFiledException.java
@@ -1,0 +1,12 @@
+package individual.freshplace.util.exception;
+
+import individual.freshplace.util.constant.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class FileConvertFiledException extends RuntimeException {
+    private final ErrorCode errorCode;
+    private final String value;
+}


### PR DESCRIPTION
 + 포맷을 통합을 위해 type이 png이면 jpeg로 변경하도록 했습니다. 상품 이미지에 글씨가 없고 색이 많은 사진이기 때문에 화질 성능은 낮지만 압축률이 더 좋은 jpeg로 통일하기로 했습니다. 