### PR TITLE
API URL 구분하기

### DIFF
--- a/src/main/frontend/public/index.html
+++ b/src/main/frontend/public/index.html
@@ -20,7 +20,7 @@
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="/manifest" href="%PUBLIC_URL%/manifest.json" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/src/main/frontend/src/App.js
+++ b/src/main/frontend/src/App.js
@@ -18,7 +18,7 @@ function App() {
     let [loginStatus, setLoginStatus] = useState();
 
     useEffect(() => {
-        axios.get('/public/category')
+        axios.get('/api/public/category')
             .then(data => {
                 setCategory(data.data);
             })

--- a/src/main/frontend/src/routes/Authentication.js
+++ b/src/main/frontend/src/routes/Authentication.js
@@ -37,7 +37,7 @@ export const Login = () => {
         }
 
         await axios.post(
-            '/login'
+            '/api/login'
             , formData
             ,{
                 headers: {
@@ -97,7 +97,7 @@ export const Login = () => {
 
 export const ReissueAuthorization = (navigate) => {
     axios
-        .patch('/reissue')
+        .patch('/api/reissue')
         .then(response => {
             setAuthorization(response.data.accessToken);
         })
@@ -112,7 +112,7 @@ export const ReissueAuthorization = (navigate) => {
 
 export const Logout = (navigate) => {
     axios
-        .delete('/members/logout')
+        .delete('/api/members/logout')
         .finally(() => {
             removeAuthorization();
             navigate('/');

--- a/src/main/frontend/src/routes/Detail.js
+++ b/src/main/frontend/src/routes/Detail.js
@@ -12,7 +12,7 @@ function Detail(props) {
     const [totalAmount, setTotalAmount] = useState(0);
 
     useEffect(() => {
-        axios.get(`/public/item/${itemSeq}`)
+        axios.get(`/api/public/item/${itemSeq}`)
             .then(data => {
                 const copy = data.data;
                 setItem(copy);

--- a/src/main/frontend/src/routes/Items.js
+++ b/src/main/frontend/src/routes/Items.js
@@ -8,7 +8,7 @@ function Items(props) {
     let {categoryName} = useParams();
 
     useEffect(() => {
-        axios.get(`/public/items/category?codeEngName=${categoryName}`)
+        axios.get(`/api/public/items/category?codeEngName=${categoryName}`)
             .then(data => {
                 let copy = [...data.data];
                 setItems(copy);

--- a/src/main/frontend/src/routes/Signup.js
+++ b/src/main/frontend/src/routes/Signup.js
@@ -14,7 +14,7 @@ function Signup(props) {
     } = useForm();
 
     const onSubmit = async (formData) => {
-        await axios.post('/public/signup', formData, {headers: {"Content-Type": `application/json`}})
+        await axios.post('/api/public/signup', formData, {headers: {"Content-Type": `application/json`}})
             .then(() => {
                 alert('축하합니다! 회원가입에 성공하였습니다.');
                 props.navigate('/login');

--- a/src/main/java/individual/freshplace/config/SecurityConfig.java
+++ b/src/main/java/individual/freshplace/config/SecurityConfig.java
@@ -64,7 +64,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     public void configure(WebSecurity web) {
         web
                 .ignoring()
-                .antMatchers("/static/**");
+                .antMatchers("/static/**")
+                .antMatchers("/favicon.ico")
+                .antMatchers("/logo192.png")
+                .antMatchers("/logo512.png")
+                .antMatchers("/manifest.json");
     }
 
     @Override
@@ -79,21 +83,20 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
                 .and()
                 .authorizeRequests()
-                .mvcMatchers(HttpMethod.POST, "/login").permitAll()
-                .mvcMatchers(HttpMethod.PATCH, "/reissue").permitAll()
-                .mvcMatchers(HttpMethod.DELETE, "/members/logout").permitAll()
-
-                .mvcMatchers(HttpMethod.GET, "/public/**").permitAll()
-                .mvcMatchers(HttpMethod.POST, "/public/**").permitAll()
-                .mvcMatchers(HttpMethod.DELETE, "/public/**").permitAll()
+                .mvcMatchers(HttpMethod.POST, "/api/login").permitAll()
+                .mvcMatchers(HttpMethod.PATCH, "/api/reissue").permitAll()
+                .mvcMatchers(HttpMethod.DELETE, "/api/members/logout").permitAll()
+                .mvcMatchers(HttpMethod.GET, "/api/public/**").permitAll()
+                .mvcMatchers(HttpMethod.POST, "/api/public/**").permitAll()
+                .mvcMatchers(HttpMethod.DELETE, "/api/public/**").permitAll()
+                .mvcMatchers(HttpMethod.GET, "/api/admin/**").hasAuthority(List.of(Authority.ADMIN.name()).toString())
+                .mvcMatchers(HttpMethod.POST, "/api/admin/**").hasAuthority(List.of(Authority.ADMIN.name()).toString())
+                .mvcMatchers(HttpMethod.PUT, "/api/admin/**").hasAuthority(List.of(Authority.ADMIN.name()).toString())
 
                 .mvcMatchers(HttpMethod.GET, "/").permitAll()
-
-                .mvcMatchers(HttpMethod.GET, "/image/**").permitAll()
-
-                .mvcMatchers(HttpMethod.GET, "/admin/**").hasAuthority(List.of(Authority.ADMIN.name()).toString())
-                .mvcMatchers(HttpMethod.POST, "/admin/**").hasAuthority(List.of(Authority.ADMIN.name()).toString())
-                .mvcMatchers(HttpMethod.PUT, "/admin/**").hasAuthority(List.of(Authority.ADMIN.name()).toString())
+                .mvcMatchers(HttpMethod.GET, "/public/**").permitAll()
+                .mvcMatchers(HttpMethod.GET, "/members/**").permitAll()
+                .mvcMatchers(HttpMethod.GET, "/login").permitAll()
 
                 .anyRequest().authenticated()
                 .and()

--- a/src/main/java/individual/freshplace/config/SecurityConfig.java
+++ b/src/main/java/individual/freshplace/config/SecurityConfig.java
@@ -2,11 +2,13 @@ package individual.freshplace.config;
 
 import individual.freshplace.util.auth.jwt.*;
 import individual.freshplace.util.constant.Authority;
+import individual.freshplace.util.filter.ViewFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
@@ -22,87 +24,120 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import java.util.Arrays;
 import java.util.List;
 
-@Configuration
 @EnableWebSecurity
-@RequiredArgsConstructor
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+public class SecurityConfig {
 
-    private final JwtTokenProvider jwtTokenProvider;
-    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
-    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    @Order(1)
+    @RequiredArgsConstructor
+    @Configuration
+    static class ApiSecurityConfig extends WebSecurityConfigurerAdapter {
 
-    @Value("${cors.alloworigin}")
-    private String localOrigin;
+        private final JwtTokenProvider jwtTokenProvider;
+        private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+        private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
-    @Bean
-    public static PropertySourcesPlaceholderConfigurer Properties() {
-        PropertySourcesPlaceholderConfigurer configurer = new PropertySourcesPlaceholderConfigurer();
-        configurer.setLocations();
-        return configurer;
+        @Value("${cors.alloworigin}")
+        private String localOrigin;
+
+        @Bean
+        public static PropertySourcesPlaceholderConfigurer Properties() {
+            PropertySourcesPlaceholderConfigurer configurer = new PropertySourcesPlaceholderConfigurer();
+            configurer.setLocations();
+            return configurer;
+        }
+
+        @Bean
+        public BCryptPasswordEncoder passwordEncoder() {
+            return new BCryptPasswordEncoder();
+        }
+
+        @Bean
+        public CorsConfigurationSource corsConfigurationSource() {
+
+            CorsConfiguration config = new CorsConfiguration();
+
+            config.setAllowCredentials(true);
+            config.addAllowedOrigin(localOrigin);
+            config.addAllowedMethod(String.valueOf(Arrays.asList(HttpMethod.GET, HttpMethod.POST, HttpMethod.PUT, HttpMethod.PATCH, HttpMethod.OPTIONS)));
+
+            UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+            source.registerCorsConfiguration("/**", config);
+            return source;
+        }
+
+        @Override
+        public void configure(WebSecurity web) {
+            web
+                    .ignoring()
+                    .antMatchers("/static/**")
+                    .antMatchers("/favicon.ico")
+                    .antMatchers("/logo192.png")
+                    .antMatchers("/logo512.png")
+                    .antMatchers("/manifest.json");
+        }
+
+        @Override
+        protected void configure(HttpSecurity http) throws Exception {
+            http
+                    .mvcMatcher("/api/**")
+                    .csrf().disable()
+                    .httpBasic().disable()
+                    .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+
+                    .and()
+                    .cors().configurationSource(corsConfigurationSource())
+
+                    .and()
+                    .authorizeRequests()
+                    .mvcMatchers(HttpMethod.POST, "/api/login").permitAll()
+                    .mvcMatchers(HttpMethod.PATCH, "/api/reissue").permitAll()
+                    .mvcMatchers(HttpMethod.DELETE, "/api/members/logout").permitAll()
+                    .mvcMatchers(HttpMethod.GET, "/api/public/**").permitAll()
+                    .mvcMatchers(HttpMethod.POST, "/api/public/**").permitAll()
+                    .mvcMatchers(HttpMethod.DELETE, "/api/public/**").permitAll()
+                    .mvcMatchers(HttpMethod.GET, "/api/admin/**").hasAuthority(List.of(Authority.ADMIN.name()).toString())
+                    .mvcMatchers(HttpMethod.POST, "/api/admin/**").hasAuthority(List.of(Authority.ADMIN.name()).toString())
+                    .mvcMatchers(HttpMethod.PUT, "/api/admin/**").hasAuthority(List.of(Authority.ADMIN.name()).toString())
+                    .anyRequest().authenticated()
+
+                    .and()
+                    .addFilterBefore(new JwtFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
+                    .exceptionHandling()
+                    .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                    .accessDeniedHandler(jwtAccessDeniedHandler);
+        }
+
     }
 
-    @Bean
-    public BCryptPasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
+    @Order(2)
+    @Configuration
+    static class ViewSecurityConfig extends WebSecurityConfigurerAdapter {
+
+        @Override
+        public void configure(WebSecurity web) {
+            web
+                    .ignoring()
+                    .antMatchers("/static/**")
+                    .antMatchers("/favicon.ico")
+                    .antMatchers("/logo192.png")
+                    .antMatchers("/logo512.png")
+                    .antMatchers("/manifest.json");
+        }
+
+        @Override
+        protected void configure(HttpSecurity http) throws Exception {
+            http
+                    .mvcMatcher("/**")
+                    .csrf().disable()
+                    .httpBasic().disable()
+                    .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                    .and()
+                    .authorizeRequests()
+                    .anyRequest()
+                    .authenticated()
+                    .and()
+                    .addFilterBefore(new ViewFilter(), UsernamePasswordAuthenticationFilter.class);
+        }
     }
 
-    @Bean
-    public CorsConfigurationSource corsConfigurationSource() {
-
-        CorsConfiguration config = new CorsConfiguration();
-
-        config.setAllowCredentials(true);
-        config.addAllowedOrigin(localOrigin);
-        config.addAllowedMethod(String.valueOf(Arrays.asList(HttpMethod.GET, HttpMethod.POST, HttpMethod.PUT, HttpMethod.PATCH, HttpMethod.OPTIONS)));
-
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", config);
-        return source;
-    }
-
-    @Override
-    public void configure(WebSecurity web) {
-        web
-                .ignoring()
-                .antMatchers("/static/**")
-                .antMatchers("/favicon.ico")
-                .antMatchers("/logo192.png")
-                .antMatchers("/logo512.png")
-                .antMatchers("/manifest.json");
-    }
-
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-        http
-                .csrf().disable()
-                .httpBasic().disable()
-                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-
-                .and()
-                .cors().configurationSource(corsConfigurationSource())
-
-                .and()
-                .authorizeRequests()
-                .mvcMatchers(HttpMethod.POST, "/api/login").permitAll()
-                .mvcMatchers(HttpMethod.PATCH, "/api/reissue").permitAll()
-                .mvcMatchers(HttpMethod.DELETE, "/api/members/logout").permitAll()
-                .mvcMatchers(HttpMethod.GET, "/api/public/**").permitAll()
-                .mvcMatchers(HttpMethod.POST, "/api/public/**").permitAll()
-                .mvcMatchers(HttpMethod.DELETE, "/api/public/**").permitAll()
-                .mvcMatchers(HttpMethod.GET, "/api/admin/**").hasAuthority(List.of(Authority.ADMIN.name()).toString())
-                .mvcMatchers(HttpMethod.POST, "/api/admin/**").hasAuthority(List.of(Authority.ADMIN.name()).toString())
-                .mvcMatchers(HttpMethod.PUT, "/api/admin/**").hasAuthority(List.of(Authority.ADMIN.name()).toString())
-
-                .mvcMatchers(HttpMethod.GET, "/").permitAll()
-                .mvcMatchers(HttpMethod.GET, "/public/**").permitAll()
-                .mvcMatchers(HttpMethod.GET, "/members/**").permitAll()
-                .mvcMatchers(HttpMethod.GET, "/login").permitAll()
-
-                .anyRequest().authenticated()
-                .and()
-                .addFilterBefore(new JwtFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
-                .exceptionHandling()
-                .authenticationEntryPoint(jwtAuthenticationEntryPoint)
-                .accessDeniedHandler(jwtAccessDeniedHandler);
-    }
 }

--- a/src/main/java/individual/freshplace/controller/AccountController.java
+++ b/src/main/java/individual/freshplace/controller/AccountController.java
@@ -16,6 +16,7 @@ import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api")
 public class AccountController {
 
     private final SignupService signupService;

--- a/src/main/java/individual/freshplace/controller/CartController.java
+++ b/src/main/java/individual/freshplace/controller/CartController.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/public/cart-item")
+@RequestMapping("/api/public/cart-item")
 public class CartController {
 
     private final CartReadService cartReadService;

--- a/src/main/java/individual/freshplace/controller/DeliveryAddressController.java
+++ b/src/main/java/individual/freshplace/controller/DeliveryAddressController.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/members/delivery-address")
+@RequestMapping("/api/members/delivery-address")
 public class DeliveryAddressController {
 
     private final DeliveryAddressService deliveryAddressService;

--- a/src/main/java/individual/freshplace/controller/ImageController.java
+++ b/src/main/java/individual/freshplace/controller/ImageController.java
@@ -11,11 +11,12 @@ import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/admin/image/upload")
 public class ImageController {
 
     private final ImageUploadService imageUploadService;
 
-    @PostMapping("/admin/image/upload")
+    @PostMapping
     @ResponseStatus(HttpStatus.ACCEPTED)
     public ImageUploadResponse itemsUploadRequest(@RequestParam("objectName") Long objectName,
                                                                   @RequestParam("image") MultipartFile multipartFile) {

--- a/src/main/java/individual/freshplace/controller/ItemController.java
+++ b/src/main/java/individual/freshplace/controller/ItemController.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api")
 public class ItemController {
 
     private final ItemService itemService;

--- a/src/main/java/individual/freshplace/controller/OrderController.java
+++ b/src/main/java/individual/freshplace/controller/OrderController.java
@@ -20,7 +20,7 @@ import java.util.List;
 @Slf4j
 @Controller
 @RequiredArgsConstructor
-@RequestMapping("/members/order")
+@RequestMapping("/api/members/order")
 public class OrderController {
 
     private final OrderService orderService;

--- a/src/main/java/individual/freshplace/controller/ProfileController.java
+++ b/src/main/java/individual/freshplace/controller/ProfileController.java
@@ -15,17 +15,18 @@ import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/members/profile")
 public class ProfileController {
 
     private final ProfileService profileService;
 
-    @GetMapping("/members/profile")
+    @GetMapping
     @Cacheable(cacheNames = Cache.PROFILE, key = "#principalDetails.getUsername()")
     public ProfileResponse getProfile(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         return profileService.getProfile(principalDetails.getUsername());
     }
 
-    @PutMapping("/members/profile")
+    @PutMapping
     @CachePut(cacheNames = Cache.ITEM, key = "#profileUpdateRequest.getMemberId()")
     public ProfileResponse updateProfile(@AuthenticationPrincipal PrincipalDetails principalDetails, @Valid @RequestBody ProfileUpdateRequest profileUpdateRequest) {
         return profileService.updateProfile(principalDetails.getUsername(), profileUpdateRequest);

--- a/src/main/java/individual/freshplace/controller/ViewController.java
+++ b/src/main/java/individual/freshplace/controller/ViewController.java
@@ -1,0 +1,19 @@
+package individual.freshplace.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.web.servlet.error.ErrorController;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import javax.servlet.http.HttpServletResponse;
+
+@Slf4j
+@Controller
+public class ViewController implements ErrorController {
+
+    @GetMapping("/error")
+    public String redirectIndex(HttpServletResponse httpServletResponse) {
+        log.error(httpServletResponse.getStatus() + " error");
+        return "index.html";
+    }
+}

--- a/src/main/java/individual/freshplace/controller/ViewController.java
+++ b/src/main/java/individual/freshplace/controller/ViewController.java
@@ -1,10 +1,8 @@
 package individual.freshplace.controller;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@Slf4j
 @Controller
 public class ViewController {
 

--- a/src/main/java/individual/freshplace/controller/ViewController.java
+++ b/src/main/java/individual/freshplace/controller/ViewController.java
@@ -1,19 +1,15 @@
 package individual.freshplace.controller;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.web.servlet.error.ErrorController;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-
-import javax.servlet.http.HttpServletResponse;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 @Slf4j
 @Controller
-public class ViewController implements ErrorController {
+public class ViewController {
 
-    @GetMapping("/error")
-    public String redirectIndex(HttpServletResponse httpServletResponse) {
-        log.error(httpServletResponse.getStatus() + " error");
+    @RequestMapping("/index")
+    public String redirectIndex() {
         return "index.html";
     }
 }

--- a/src/main/java/individual/freshplace/util/filter/ViewFilter.java
+++ b/src/main/java/individual/freshplace/util/filter/ViewFilter.java
@@ -14,7 +14,7 @@ public class ViewFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
         String uri = request.getRequestURI().toString();
-        if (uri.startsWith("/api")) {
+        if (uri.startsWith("/api/")) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/main/java/individual/freshplace/util/filter/ViewFilter.java
+++ b/src/main/java/individual/freshplace/util/filter/ViewFilter.java
@@ -1,0 +1,23 @@
+package individual.freshplace.util.filter;
+
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class ViewFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        String uri = request.getRequestURI().toString();
+        if (uri.startsWith("/api")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        request.getRequestDispatcher("/index").forward(request, response);
+    }
+}


### PR DESCRIPTION
페이지와 API url 구분을 위해 '/api' prefix를 생성했습니다. 현재 versioning은 관리하지 않으므로 'v1...2..'prefix는 생성하지 않았습니다.

![security filter chain](https://user-images.githubusercontent.com/80368511/234387250-45970407-ed4c-4979-b6f1-1da05dffb417.png)

security설정은 filterChain을 2개 사용해서 url을 구분했습니다. api요청이 아닌 request는 두번째 필터체인에서 index로 포워드 됩니다. 