### PR TITLE
카테고리 상단바 페이지 변경

### DIFF
--- a/src/main/frontend/src/App.js
+++ b/src/main/frontend/src/App.js
@@ -54,8 +54,13 @@ function App() {
                                                             <NavDropdown.Item key={subCategory.subCategoryEngName}
                                                                               onClick={() => {
                                                                                   navigate(`public/items/category/${subCategory.subCategoryEngName}`)
-                                                                              }}>
-                                                                {subCategory.subCategoryKorName}
+                                                                              }}
+                                                                              disabled={
+                                                                                  subCategory.subCategoryEngName !== 'driedFruit'
+                                                                                  && subCategory.subCategoryEngName !== 'coffeeDrink'
+                                                                              }>
+                                                                        {subCategory.subCategoryKorName}
+
                                                             </NavDropdown.Item>
                                                             <NavDropdown.Divider/>
                                                         </>


### PR DESCRIPTION
현재 DB에 아이템 없는 카테고리는 disabled처리 했습니다. 처음엔 백엔드에서 상품 존재 유무 체크를 하려고 했으나 본래 정상적인 서비스라면 상품을 모두 가지고 있는게 보통이며, 현재 DB 저장된 카테고리 종류가 두가지 뿐이라 간편하게 프론트에서 처리했습니다.  (카테고리 뭐 있는지는 보여주고 싶기도 했습니다!)